### PR TITLE
fix: show tool_name before thinking in event Action column

### DIFF
--- a/src/client/components/EventTable.tsx
+++ b/src/client/components/EventTable.tsx
@@ -40,16 +40,6 @@ interface ToolLabel {
 function getToolLabel(e: Event): ToolLabel {
   // assistant: tool_name in blue, or stop_reason in gray
   if (e.type === "assistant") {
-    // Check for thinking blocks
-    if (e.raw) {
-      try {
-        const parsed = JSON.parse(e.raw);
-        const content = parsed?.message?.content;
-        if (Array.isArray(content) && content[0]?.type === "thinking") {
-          return { text: "Thinking", style: "tool" };
-        }
-      } catch {}
-    }
     if (e.tool_name) {
       // Agent tool: show subagent type as postfix
       if (e.tool_name === "Agent" && e.raw) {
@@ -67,6 +57,16 @@ function getToolLabel(e: Event): ToolLabel {
         } catch {}
       }
       return { text: e.tool_name, style: "tool" };
+    }
+    // Pure thinking response (no tool call)
+    if (e.raw) {
+      try {
+        const parsed = JSON.parse(e.raw);
+        const content = parsed?.message?.content;
+        if (Array.isArray(content) && content[0]?.type === "thinking") {
+          return { text: "Thinking", style: "tool" };
+        }
+      } catch {}
     }
     if (e.stop_reason) return { text: e.stop_reason, style: "hook" };
     return { text: "\u2014", style: "hook" };


### PR DESCRIPTION
## Summary
- Fixed `getToolLabel()` priority in `EventTable.tsx` — tool_name check now runs before thinking block detection
- Extended-thinking assistant events with both `thinking` + `tool_use` blocks were showing "Thinking" label instead of the actual tool name (e.g. "Skill", "Agent")
- Thinking label is now only shown for pure thinking responses with no associated tool call

## Root Cause
`getToolLabel()` parsed `content[0]?.type === "thinking"` and returned early, before checking `e.tool_name`. Since extended thinking prepends a thinking block to every response including tool calls, any Skill/Agent invocation made via extended thinking was mislabeled.

## Test plan
- [ ] Open a session that used extended thinking (Claude with thinking enabled)
- [ ] Verify tool call rows show "Skill", "Agent", or the actual `tool_name` value — not "Thinking"
- [ ] Verify pure thinking responses (no tool call) still show "Thinking"

🤖 Generated with [Claude Code](https://claude.com/claude-code)