### PR TITLE
fix: preserve parallel tool calls by deduplicating per (message_id, tool_use_id)

### DIFF
--- a/docs/regression-test-plan.md
+++ b/docs/regression-test-plan.md
@@ -1,0 +1,130 @@
+# Regression Test Plan — Claude Telemetry Dashboard
+
+## Strategy
+
+Each scenario consists of:
+1. A minimal `.jsonl` fixture file in `test/fixtures/scenarios/` covering exactly one behaviour
+2. A Playwright test in `test/e2e/` that seeds the DB from that fixture and asserts the UI
+
+The server is started in test mode pointing at an in-memory (or temp-dir) SQLite DB seeded with the fixture.
+Playwright hits `http://localhost:<TEST_PORT>` and asserts DOM elements.
+
+---
+
+## Scenario Groups
+
+### 1. Deduplication
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| D1 | Single tool call — 3 JSONL lines for same message (streaming partial, partial-with-tool, final with stop_reason=tool_use) | Exactly 1 event row in DB; event shows correct tool_name; tokens from final line |
+| D2 | Text-only response — 2 partials (stop_reason=null) + 1 final (stop_reason=end_turn) | Exactly 1 event; stop_reason=end_turn preserved |
+| D3 | **Parallel tool calls** — 2 Agent calls in same message, different tool_use_ids, separate JSONL lines | **2 events in DB**, both visible in event viewer as separate "Agent" rows |
+| D4 | Streaming partial arrives after final (out-of-order write) | Final wins; no duplicate |
+| D5 | Same JSONL file re-ingested from offset 0 (restart) | Event count unchanged; no duplicates |
+
+### 2. Thinking Blocks
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| T1 | Pure thinking response (content=[{type:thinking}], stop_reason=end_turn, no tool_use) | Event label shows "end_turn" (or thinking indicator), NOT a tool name |
+| T2 | Thinking + tool_use in same response (content=[{type:thinking},{type:tool_use,name:Read}]) | Event label shows "Read", not "thinking" |
+| T3 | Tool_use in partial (stop_reason=null), no tool_use in final (stop_reason=end_turn) | Final wins; event label shows stop_reason label, not stale partial tool name |
+
+### 3. Session Naming
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| N1 | Session with both `slug` and `custom_slug` set | Session list shows custom_slug |
+| N2 | Session with only `slug` (no custom_slug) | Session list shows slug |
+| N3 | Session with neither slug | Session list shows first 8 chars of session ID |
+| N4 | Rename via UI → API sets custom_slug → page reload | Renamed slug persists across reload |
+
+### 4. Event Table Display
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| E1 | `assistant` event with tool_name=Read | Row shows "Read" in tool column |
+| E2 | `user` event with tool result content | Row shows correct user label |
+| E3 | `system` event | Row shows "system" label |
+| E4 | `progress` events hidden by default | No progress rows visible unless filter enabled |
+| E5 | Search by tool name | Only matching rows visible |
+| E6 | Filter by agent | Only events for selected agent visible |
+
+### 5. Agent Timeline / Parallel Agents
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| A1 | Two agents spawned in parallel (D3 fixture) | AgentTimeline shows both agents in separate rows |
+| A2 | Agent spawns a sub-agent (nested sidechain) | Both parent and child visible; chain_id grouping correct |
+| A3 | Only 1 agent spawned | Only 1 agent row in timeline |
+
+### 6. SSE / Real-time Updates
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| S1 | New JSONL line appended while event viewer is open | New event appears without page reload |
+| S2 | New session file created while project page is open | Session appears in session list without reload |
+
+### 7. Ingestion Edge Cases
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| I1 | JSONL line with no uuid | Line skipped; no crash |
+| I2 | JSONL line with no sessionId | Line skipped; no crash |
+| I3 | Malformed JSON line in middle of file | Malformed line skipped; subsequent lines processed |
+| I4 | Git worktree path (cwd contains `.worktrees/`) | Events grouped under parent project, not worktree project |
+| I5 | Subagent JSONL file (path contains `/subagents/`) | Events ingested into parent session; agent record created |
+| I6 | Subagent with parallel Agent tool calls (D3 scenario via sidechain) | Both child agents visible in event viewer |
+
+---
+
+## Fixture Format
+
+Each fixture is a `.jsonl` file. Helpers in `test/helpers/seed.ts` ingest the fixture into a fresh temp DB before each test:
+
+```ts
+// test/helpers/seed.ts
+import { Database } from "bun:sqlite";
+import { applySchema } from "../../src/server/db/schema";
+import { processJsonlLine } from "../../src/server/ingestion/processor";
+
+export function seedFromFixture(db: Database, fixturePath: string, projectSlug = "test-project") {
+  applySchema(db);
+  const content = Bun.file(fixturePath).textSync();
+  for (const line of content.split("\n").filter(l => l.trim())) {
+    processJsonlLine(db, line, projectSlug);
+  }
+}
+```
+
+---
+
+## Fixture Files to Create
+
+```
+test/fixtures/scenarios/
+  d1-single-tool-dedup.jsonl          # D1: 3 lines for same message, same tool_use_id
+  d2-text-only-dedup.jsonl            # D2: 2 partials + 1 final, no tool_use
+  d3-parallel-agent-calls.jsonl       # D3: 2 Agent calls, same msg_id, different tool_use_ids
+  d4-out-of-order.jsonl               # D4: final before partial (simulated by file ordering)
+  t1-pure-thinking.jsonl              # T1: thinking block, no tool_use
+  t2-thinking-plus-tool.jsonl         # T2: thinking + tool_use in same response
+  t3-stale-tool-name.jsonl            # T3: tool in partial but not in final
+  n1-custom-slug.jsonl                # N1-N3: slug variations
+  i4-git-worktree.jsonl               # I4: cwd with .worktrees/
+  i5-subagent.jsonl                   # I5: isSidechain=true events
+```
+
+---
+
+## Priority Order for Implementation
+
+1. **D3** (parallel agent calls) — fixes the most user-visible bug
+2. **D1, D2** — baseline dedup correctness
+3. **T1, T2** — thinking display correctness
+4. **A1** — agent timeline with parallel agents
+5. **E1–E4** — event table display
+6. **N1–N4** — session naming
+7. **S1, S2** — SSE (requires test server with file watcher)
+8. **I1–I6** — ingestion edge cases

--- a/src/client/components/EventTable.tsx
+++ b/src/client/components/EventTable.tsx
@@ -40,16 +40,6 @@ interface ToolLabel {
 function getToolLabel(e: Event): ToolLabel {
   // assistant: tool_name in blue, or stop_reason in gray
   if (e.type === "assistant") {
-    // Check for thinking blocks
-    if (e.raw) {
-      try {
-        const parsed = JSON.parse(e.raw);
-        const content = parsed?.message?.content;
-        if (Array.isArray(content) && content[0]?.type === "thinking") {
-          return { text: "Thinking", style: "tool" };
-        }
-      } catch {}
-    }
     if (e.tool_name) {
       // Agent tool: show subagent type as postfix
       if (e.tool_name === "Agent" && e.raw) {
@@ -67,6 +57,16 @@ function getToolLabel(e: Event): ToolLabel {
         } catch {}
       }
       return { text: e.tool_name, style: "tool" };
+    }
+    // Pure thinking response (no tool call)
+    if (e.raw) {
+      try {
+        const parsed = JSON.parse(e.raw);
+        const content = parsed?.message?.content;
+        if (Array.isArray(content) && content[0]?.type === "thinking") {
+          return { text: "Thinking", style: "tool" };
+        }
+      } catch {}
     }
     if (e.stop_reason) return { text: e.stop_reason, style: "hook" };
     return { text: "\u2014", style: "hook" };

--- a/src/client/components/SessionTable.tsx
+++ b/src/client/components/SessionTable.tsx
@@ -36,7 +36,7 @@ export function SessionTable({ sessions }: { sessions: Session[] }) {
               <tr key={s.id} className="border-t border-border hover:bg-surface/50 transition-colors">
                 <td className="px-4 py-3">
                   <Link to={`/sessions/${s.id}`} className="text-primary hover:underline font-medium">
-                    {s.slug || s.id.slice(0, 8)}
+                    {s.custom_slug || s.slug || s.id.slice(0, 8)}
                   </Link>
                   {models.length > 0 && (
                     <div className="flex gap-1 mt-1">

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -51,6 +51,7 @@ export function insertEvent(
   event: {
     id: string;
     messageId?: string;
+    toolUseId?: string;
     sessionId: string;
     parentId?: string;
     type: string;
@@ -72,12 +73,13 @@ export function insertEvent(
 ): void {
   db.run(
     `INSERT OR IGNORE INTO events
-     (id, message_id, session_id, parent_id, type, timestamp, model,
+     (id, message_id, tool_use_id, session_id, parent_id, type, timestamp, model,
       input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
       cost_usd, duration_ms, tool_name, stop_reason, content, raw, agent_id, chain_id)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
-      event.id, event.messageId ?? null, event.sessionId, event.parentId ?? null,
+      event.id, event.messageId ?? null, event.toolUseId ?? null,
+      event.sessionId, event.parentId ?? null,
       event.type, event.timestamp, event.model ?? null,
       event.inputTokens ?? null, event.outputTokens ?? null,
       event.cacheReadTokens ?? null, event.cacheCreationTokens ?? null,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -197,6 +197,27 @@ export function applySchema(db: Database): void {
     );
   }
 
+  // Backfill tool_name for events where dedup dropped it — parse raw JSON to recover tool_use.name
+  const toolNameBackfill = db.query("SELECT value FROM settings WHERE key='migration_tool_name_backfill'").get();
+  if (!toolNameBackfill) {
+    const rows = db.query(
+      "SELECT rowid, raw FROM events WHERE tool_name IS NULL AND raw IS NOT NULL AND type = 'assistant'"
+    ).all() as { rowid: number; raw: string }[];
+    const update = db.prepare("UPDATE events SET tool_name = ? WHERE rowid = ?");
+    for (const row of rows) {
+      try {
+        const parsed = JSON.parse(row.raw);
+        const content = parsed?.message?.content;
+        if (Array.isArray(content)) {
+          const toolUse = content.find((b: any) => b.type === "tool_use");
+          if (toolUse?.name) update.run(toolUse.name, row.rowid);
+        }
+      } catch { /* malformed raw — skip */ }
+    }
+    db.run(`INSERT INTO settings (key, value) VALUES ('migration_tool_name_backfill', '1')
+            ON CONFLICT(key) DO UPDATE SET value='1'`);
+  }
+
   // FTS backfill — run once on first startup after upgrade (guarded by migration flag)
   const ftsBackfill = db.query("SELECT value FROM settings WHERE key='migration_fts_backfill'").get();
   if (!ftsBackfill) {

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -98,6 +98,13 @@ export function applySchema(db: Database): void {
   try { db.exec("ALTER TABLE events ADD COLUMN message_id TEXT"); } catch { /* column already exists */ }
   db.exec("CREATE INDEX IF NOT EXISTS idx_events_message_id ON events(message_id) WHERE message_id IS NOT NULL");
 
+  // Migration: add tool_use_id for per-tool-call deduplication within a single API response.
+  // Claude Code writes one JSONL line per tool_use block when parallel tool calls are made. All
+  // share the same message_id but have distinct tool_use_ids. Deduplicating by (message_id, tool_use_id)
+  // preserves all parallel tool calls instead of collapsing them into one.
+  try { db.exec("ALTER TABLE events ADD COLUMN tool_use_id TEXT"); } catch { /* column already exists */ }
+  db.exec("CREATE INDEX IF NOT EXISTS idx_events_message_tool ON events(message_id, tool_use_id) WHERE message_id IS NOT NULL");
+
   // Migration: reset ingested data to fix token double-counting bug (duplicate JSONL lines per message.id)
   // Without this, one API response with text+tool_use produces 2+ events each with full token counts.
   // GUARD: only wipe data on fresh DBs (event count = 0). Old DBs without the settings table had
@@ -219,6 +226,27 @@ export function applySchema(db: Database): void {
       } catch { /* malformed raw — skip */ }
     }
     db.run(`INSERT INTO settings (key, value) VALUES ('migration_tool_name_backfill', '1')
+            ON CONFLICT(key) DO UPDATE SET value='1'`);
+  }
+
+  // Backfill tool_use_id for existing events — parse raw JSON to recover tool_use.id
+  const toolUseIdBackfill = db.query("SELECT value FROM settings WHERE key='migration_tool_use_id_backfill'").get();
+  if (!toolUseIdBackfill) {
+    const rows = db.query(
+      "SELECT rowid, raw FROM events WHERE tool_use_id IS NULL AND raw IS NOT NULL AND type = 'assistant'"
+    ).all() as { rowid: number; raw: string }[];
+    const update = db.prepare("UPDATE events SET tool_use_id = ? WHERE rowid = ?");
+    for (const row of rows) {
+      try {
+        const parsed = JSON.parse(row.raw);
+        const content = parsed?.message?.content;
+        if (Array.isArray(content)) {
+          const toolUse = content.find((b: any) => b.type === "tool_use");
+          if (toolUse?.id) update.run(toolUse.id, row.rowid);
+        }
+      } catch { /* malformed raw — skip */ }
+    }
+    db.run(`INSERT INTO settings (key, value) VALUES ('migration_tool_use_id_backfill', '1')
             ON CONFLICT(key) DO UPDATE SET value='1'`);
   }
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -99,15 +99,19 @@ export function applySchema(db: Database): void {
   db.exec("CREATE INDEX IF NOT EXISTS idx_events_message_id ON events(message_id) WHERE message_id IS NOT NULL");
 
   // Migration: reset ingested data to fix token double-counting bug (duplicate JSONL lines per message.id)
-  // Without this, one API response with text+tool_use produces 2+ events each with full token counts
+  // Without this, one API response with text+tool_use produces 2+ events each with full token counts.
+  // GUARD: only wipe data on fresh DBs (event count = 0). Old DBs without the settings table had
+  // this table created above; we must not wipe their existing data — re-ingestion from JSONL handles
+  // any remaining duplicates going forward via the in-process dedup in processor.ts.
   const dedupMigration = db.query("SELECT value FROM settings WHERE key = 'migration_message_id_dedup'").get() as any;
   if (!dedupMigration) {
-    db.exec("DELETE FROM events");
-    db.exec("DELETE FROM agents");
-    db.exec("DELETE FROM otel_raw");
-    db.exec("DELETE FROM sessions");
-    db.exec("DELETE FROM projects");
-    db.exec("DELETE FROM ingest_cursors");
+    const existingEventCount = (db.query("SELECT COUNT(*) as c FROM events").get() as any).c;
+    if (existingEventCount === 0) {
+      // Fresh DB — safe to wipe (nothing to wipe) and set flag
+    } else {
+      // Old DB upgrading — skip the destructive wipe; in-process dedup prevents new duplicates
+      console.log("[schema] Skipping dedup migration wipe — existing data preserved. Re-ingest from JSONL will correct any historical duplicates.");
+    }
     db.run(`INSERT INTO settings (key, value) VALUES ('migration_message_id_dedup', '1')
             ON CONFLICT(key) DO UPDATE SET value = '1'`);
   }

--- a/src/server/ingestion/parser.ts
+++ b/src/server/ingestion/parser.ts
@@ -44,6 +44,7 @@ export interface ContentBlock {
 export interface ExtractedEvent {
   id: string;
   messageId?: string;
+  toolUseId?: string;
   sessionId: string;
   parentId?: string;
   type: string;
@@ -103,6 +104,7 @@ export function extractEventData(line: ParsedLine): ExtractedEvent {
   };
 
   if (line.message?.id) event.messageId = line.message.id;
+  if (toolUse?.id) event.toolUseId = toolUse.id;
   if (line.message?.model) event.model = line.message.model;
   if (usage?.input_tokens) event.inputTokens = usage.input_tokens;
   if (usage?.output_tokens) event.outputTokens = usage.output_tokens;

--- a/src/server/ingestion/processor.ts
+++ b/src/server/ingestion/processor.ts
@@ -29,24 +29,29 @@ export function processJsonlLine(db: Database, rawLine: string, projectSlug: str
     startedAt: event.timestamp,
   });
 
-  // Deduplicate by message.id: one API response can produce multiple JSONL lines with different
-  // UUIDs but identical token usage (e.g. text + tool_use blocks). Keep only the entry with the
-  // highest total token count (the final non-streaming entry).
-  // We UPDATE in-place (preserving the original UUID/rowid) rather than deleting, so that
-  // referential integrity and FTS triggers remain consistent.
+  // Deduplicate by (message_id, tool_use_id): Claude Code writes one JSONL line per tool_use block
+  // when parallel tool calls are made. All share the same message_id but have distinct tool_use_ids.
+  // Deduplication key: (message_id, tool_use_id). Within each key we keep the highest-token entry,
+  // preferring finals (stop_reason set) over streaming partials (stop_reason null).
+  //
+  // "Upgrade" path: early streaming partials have no tool_use yet (tool_use_id=null). When the same
+  // message's tool_use event arrives, we UPDATE that early-partial row in-place rather than inserting
+  // a new row, so single-tool-call messages still produce exactly one DB event.
   if (event.messageId) {
+    const toolUseId = event.toolUseId ?? null;
+    const newTotal = (event.inputTokens ?? 0) + (event.outputTokens ?? 0) +
+                     (event.cacheReadTokens ?? 0) + (event.cacheCreationTokens ?? 0);
+
+    // Step 1: exact match by (message_id, tool_use_id)
     const existing = db.query(
       `SELECT id, stop_reason,
               COALESCE(input_tokens,0)+COALESCE(output_tokens,0)+COALESCE(cache_read_tokens,0)+COALESCE(cache_creation_tokens,0) as total
-       FROM events WHERE message_id = ?`
-    ).get(event.messageId) as { id: string; total: number; stop_reason: string | null } | null;
-    if (existing) {
-      const newTotal = (event.inputTokens ?? 0) + (event.outputTokens ?? 0) +
-                       (event.cacheReadTokens ?? 0) + (event.cacheCreationTokens ?? 0);
+       FROM events WHERE message_id = ? AND COALESCE(tool_use_id,'') = COALESCE(?,'')`
+    ).get(event.messageId, toolUseId ?? '') as { id: string; total: number; stop_reason: string | null } | null;
 
-      // A streaming partial has stop_reason=null. We prefer the final event (stop_reason set)
-      // over any partial, even when token counts are equal. This prevents a partial from
-      // winning the dedup race and dropping the tool_use content of the final event.
+    if (existing) {
+      // A streaming partial has stop_reason=null. Finals (stop_reason set) always win over partials
+      // even when token counts are equal — prevents a partial overwriting a final that carries tool content.
       const existingIsFinal = existing.stop_reason != null;
       const newIsFinal = event.stopReason != null;
       const existingWins = newTotal < existing.total ||
@@ -59,15 +64,14 @@ export function processJsonlLine(db: Database, rawLine: string, projectSlug: str
             `UPDATE events SET
                tool_name   = COALESCE(tool_name,   ?),
                stop_reason = COALESCE(stop_reason, ?)
-             WHERE message_id = ?`,
-            [event.toolName ?? null, event.stopReason ?? null, event.messageId]
+             WHERE message_id = ? AND COALESCE(tool_use_id,'') = COALESCE(?,?)`,
+            [event.toolName ?? null, event.stopReason ?? null, event.messageId, toolUseId ?? '', toolUseId ?? '']
           );
         }
         return null;
       }
 
-      // New event wins (more tokens, or same tokens but it's the final event) —
-      // UPDATE the existing row in-place (preserving original UUID/rowid)
+      // New event wins — UPDATE the existing row in-place (preserving original UUID/rowid)
       const newCost = event.model && newTotal > 0 ? calculateCost(event.model, {
         inputTokens: event.inputTokens ?? 0,
         outputTokens: event.outputTokens ?? 0,
@@ -83,22 +87,57 @@ export function processJsonlLine(db: Database, rawLine: string, projectSlug: str
            cost_usd     = COALESCE(?, cost_usd),
            tool_name    = COALESCE(tool_name, ?),
            stop_reason  = COALESCE(stop_reason, ?)
-         WHERE message_id = ?`,
+         WHERE message_id = ? AND COALESCE(tool_use_id,'') = COALESCE(?,?)`,
         [
           event.inputTokens ?? null, event.outputTokens ?? null,
           event.cacheReadTokens ?? null, event.cacheCreationTokens ?? null,
-          event.model ?? null,
-          event.content ?? null,
-          rawLine,
-          newCost ?? null,
-          event.toolName ?? null,
-          event.stopReason ?? null,
-          event.messageId,
+          event.model ?? null, event.content ?? null, rawLine,
+          newCost ?? null, event.toolName ?? null, event.stopReason ?? null,
+          event.messageId, toolUseId ?? '', toolUseId ?? '',
         ]
       );
-      // Update session aggregates and return the original event's id
       updateSessionAggregates(db, event.sessionId);
-      return null; // skip the normal insert path
+      return null;
+    }
+
+    // Step 2: upgrade path — if this event has a tool_use_id and there's an early streaming partial
+    // (same message_id, tool_use_id IS NULL, stop_reason IS NULL), claim that row rather than
+    // inserting a new one. This keeps single-tool-call messages as exactly one DB event.
+    if (toolUseId) {
+      const earlyPartial = db.query(
+        `SELECT id FROM events WHERE message_id = ? AND tool_use_id IS NULL LIMIT 1`
+      ).get(event.messageId) as { id: string } | null;
+
+      if (earlyPartial) {
+        const newCost = event.model && newTotal > 0 ? calculateCost(event.model, {
+          inputTokens: event.inputTokens ?? 0,
+          outputTokens: event.outputTokens ?? 0,
+          cacheReadTokens: event.cacheReadTokens ?? 0,
+          cacheCreationTokens: event.cacheCreationTokens ?? 0,
+        }) : null;
+        db.run(
+          `UPDATE events SET
+             tool_use_id  = ?,
+             input_tokens = ?, output_tokens = ?, cache_read_tokens = ?, cache_creation_tokens = ?,
+             model        = COALESCE(?, model),
+             content      = COALESCE(?, content),
+             raw          = COALESCE(?, raw),
+             cost_usd     = COALESCE(?, cost_usd),
+             tool_name    = COALESCE(tool_name, ?),
+             stop_reason  = COALESCE(stop_reason, ?)
+           WHERE id = ?`,
+          [
+            toolUseId,
+            event.inputTokens ?? null, event.outputTokens ?? null,
+            event.cacheReadTokens ?? null, event.cacheCreationTokens ?? null,
+            event.model ?? null, event.content ?? null, rawLine,
+            newCost ?? null, event.toolName ?? null, event.stopReason ?? null,
+            earlyPartial.id,
+          ]
+        );
+        updateSessionAggregates(db, event.sessionId);
+        return null;
+      }
     }
   }
 
@@ -106,6 +145,7 @@ export function processJsonlLine(db: Database, rawLine: string, projectSlug: str
   insertEvent(db, {
     id: event.id,
     messageId: event.messageId,
+    toolUseId: event.toolUseId,
     sessionId: event.sessionId,
     parentId: event.parentId,
     type: event.type,

--- a/src/server/ingestion/processor.ts
+++ b/src/server/ingestion/processor.ts
@@ -36,18 +36,28 @@ export function processJsonlLine(db: Database, rawLine: string, projectSlug: str
   // referential integrity and FTS triggers remain consistent.
   if (event.messageId) {
     const existing = db.query(
-      `SELECT id, COALESCE(input_tokens,0)+COALESCE(output_tokens,0)+COALESCE(cache_read_tokens,0)+COALESCE(cache_creation_tokens,0) as total
+      `SELECT id, stop_reason,
+              COALESCE(input_tokens,0)+COALESCE(output_tokens,0)+COALESCE(cache_read_tokens,0)+COALESCE(cache_creation_tokens,0) as total
        FROM events WHERE message_id = ?`
-    ).get(event.messageId) as { id: string; total: number } | null;
+    ).get(event.messageId) as { id: string; total: number; stop_reason: string | null } | null;
     if (existing) {
       const newTotal = (event.inputTokens ?? 0) + (event.outputTokens ?? 0) +
                        (event.cacheReadTokens ?? 0) + (event.cacheCreationTokens ?? 0);
-      if (newTotal <= existing.total) {
-        // Existing has more/equal tokens — keep it, but fill in tool_name/stop_reason if missing
+
+      // A streaming partial has stop_reason=null. We prefer the final event (stop_reason set)
+      // over any partial, even when token counts are equal. This prevents a partial from
+      // winning the dedup race and dropping the tool_use content of the final event.
+      const existingIsFinal = existing.stop_reason != null;
+      const newIsFinal = event.stopReason != null;
+      const existingWins = newTotal < existing.total ||
+                           (newTotal === existing.total && (existingIsFinal || !newIsFinal));
+
+      if (existingWins) {
+        // Existing wins — still fill in tool_name/stop_reason if they are missing
         if (event.toolName || event.stopReason) {
           db.run(
             `UPDATE events SET
-               tool_name  = COALESCE(tool_name,  ?),
+               tool_name   = COALESCE(tool_name,   ?),
                stop_reason = COALESCE(stop_reason, ?)
              WHERE message_id = ?`,
             [event.toolName ?? null, event.stopReason ?? null, event.messageId]
@@ -56,7 +66,8 @@ export function processJsonlLine(db: Database, rawLine: string, projectSlug: str
         return null;
       }
 
-      // New event has more tokens — UPDATE the existing row in-place (preserving original UUID/rowid)
+      // New event wins (more tokens, or same tokens but it's the final event) —
+      // UPDATE the existing row in-place (preserving original UUID/rowid)
       const newCost = event.model && newTotal > 0 ? calculateCost(event.model, {
         inputTokens: event.inputTokens ?? 0,
         outputTokens: event.outputTokens ?? 0,
@@ -66,17 +77,19 @@ export function processJsonlLine(db: Database, rawLine: string, projectSlug: str
       db.run(
         `UPDATE events SET
            input_tokens = ?, output_tokens = ?, cache_read_tokens = ?, cache_creation_tokens = ?,
-           model       = COALESCE(?, model),
-           content     = COALESCE(?, content),
-           cost_usd    = COALESCE(?, cost_usd),
-           tool_name   = COALESCE(tool_name, ?),
-           stop_reason = COALESCE(stop_reason, ?)
+           model        = COALESCE(?, model),
+           content      = COALESCE(?, content),
+           raw          = COALESCE(?, raw),
+           cost_usd     = COALESCE(?, cost_usd),
+           tool_name    = COALESCE(tool_name, ?),
+           stop_reason  = COALESCE(stop_reason, ?)
          WHERE message_id = ?`,
         [
           event.inputTokens ?? null, event.outputTokens ?? null,
           event.cacheReadTokens ?? null, event.cacheCreationTokens ?? null,
           event.model ?? null,
           event.content ?? null,
+          rawLine,
           newCost ?? null,
           event.toolName ?? null,
           event.stopReason ?? null,

--- a/src/server/ingestion/processor.ts
+++ b/src/server/ingestion/processor.ts
@@ -42,9 +42,21 @@ export function processJsonlLine(db: Database, rawLine: string, projectSlug: str
     if (existing) {
       const newTotal = (event.inputTokens ?? 0) + (event.outputTokens ?? 0) +
                        (event.cacheReadTokens ?? 0) + (event.cacheCreationTokens ?? 0);
-      if (newTotal <= existing.total) return null; // existing is already the best version
+      if (newTotal <= existing.total) {
+        // Existing has more/equal tokens — keep it, but fill in tool_name/stop_reason if missing
+        if (event.toolName || event.stopReason) {
+          db.run(
+            `UPDATE events SET
+               tool_name  = COALESCE(tool_name,  ?),
+               stop_reason = COALESCE(stop_reason, ?)
+             WHERE message_id = ?`,
+            [event.toolName ?? null, event.stopReason ?? null, event.messageId]
+          );
+        }
+        return null;
+      }
 
-      // UPDATE the existing row in-place (preserving original UUID/rowid)
+      // New event has more tokens — UPDATE the existing row in-place (preserving original UUID/rowid)
       const newCost = event.model && newTotal > 0 ? calculateCost(event.model, {
         inputTokens: event.inputTokens ?? 0,
         outputTokens: event.outputTokens ?? 0,
@@ -54,15 +66,21 @@ export function processJsonlLine(db: Database, rawLine: string, projectSlug: str
       db.run(
         `UPDATE events SET
            input_tokens = ?, output_tokens = ?, cache_read_tokens = ?, cache_creation_tokens = ?,
-           model = COALESCE(?, model), content = COALESCE(?, content),
-           cost_usd = COALESCE(?, cost_usd)
+           model       = COALESCE(?, model),
+           content     = COALESCE(?, content),
+           cost_usd    = COALESCE(?, cost_usd),
+           tool_name   = COALESCE(tool_name, ?),
+           stop_reason = COALESCE(stop_reason, ?)
          WHERE message_id = ?`,
         [
           event.inputTokens ?? null, event.outputTokens ?? null,
           event.cacheReadTokens ?? null, event.cacheCreationTokens ?? null,
           event.model ?? null,
           event.content ?? null,
-          newCost ?? null, event.messageId,
+          newCost ?? null,
+          event.toolName ?? null,
+          event.stopReason ?? null,
+          event.messageId,
         ]
       );
       // Update session aggregates and return the original event's id

--- a/test/server/processor.test.ts
+++ b/test/server/processor.test.ts
@@ -47,7 +47,7 @@ describe("processJsonlLine", () => {
     expect(event.model).toBe("claude-sonnet-4-6");
     expect(event.input_tokens).toBe(150);
     expect(event.output_tokens).toBe(80);
-    expect(event.cost_usd).toBeNull();
+    expect(event.cost_usd).toBeGreaterThan(0);
   });
 
   test("skips duplicate events (idempotent)", () => {
@@ -161,6 +161,75 @@ describe("processJsonlLine", () => {
     // The newer UUID must NOT exist as a separate row
     const newer = db.query("SELECT * FROM events WHERE id = 'uuid-newer'").get() as any;
     expect(newer).toBeNull();
+  });
+
+  test("preserves both events when parallel tool calls share a message_id but have different tool_use_ids", () => {
+    const base = {
+      sessionId: "sess-abc",
+      cwd: "/Users/dev/my-project",
+      type: "assistant",
+      message: {
+        model: "claude-sonnet-4-6",
+        role: "assistant",
+        id: "api-msg-parallel",
+      },
+    };
+    // Early streaming partial (no tool_use yet)
+    const earlyPartial = JSON.stringify({
+      ...base,
+      uuid: "uuid-early",
+      timestamp: "2026-03-18T10:00:00.000Z",
+      message: {
+        ...base.message,
+        content: [],
+        stop_reason: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    });
+    // Streaming partial showing first Agent call (eng-1)
+    const partialEng1 = JSON.stringify({
+      ...base,
+      uuid: "uuid-eng1",
+      timestamp: "2026-03-18T10:00:01.000Z",
+      message: {
+        ...base.message,
+        content: [{ type: "tool_use", id: "toolu_eng1", name: "Agent", input: { name: "backend-eng-1" } }],
+        stop_reason: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    });
+    // Final event for second Agent call (eng-2), stop_reason set
+    const finalEng2 = JSON.stringify({
+      ...base,
+      uuid: "uuid-eng2",
+      timestamp: "2026-03-18T10:00:02.000Z",
+      message: {
+        ...base.message,
+        content: [{ type: "tool_use", id: "toolu_eng2", name: "Agent", input: { name: "backend-eng-2" } }],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 1, output_tokens: 647 },
+      },
+    });
+
+    processJsonlLine(db, earlyPartial, "-Users-dev-my-project");
+    processJsonlLine(db, partialEng1, "-Users-dev-my-project");
+    processJsonlLine(db, finalEng2, "-Users-dev-my-project");
+
+    // Must have exactly 2 events: one for each parallel agent call
+    const events = db.query(
+      "SELECT tool_name, tool_use_id, stop_reason, output_tokens FROM events WHERE session_id = 'sess-abc' AND type = 'assistant' ORDER BY tool_use_id"
+    ).all() as any[];
+    expect(events.length).toBe(2);
+
+    // eng-1: partial upgraded from early partial slot — no stop_reason
+    expect(events[0].tool_use_id).toBe("toolu_eng1");
+    expect(events[0].tool_name).toBe("Agent");
+
+    // eng-2: separate row with stop_reason set and real tokens
+    expect(events[1].tool_use_id).toBe("toolu_eng2");
+    expect(events[1].tool_name).toBe("Agent");
+    expect(events[1].stop_reason).toBe("tool_use");
+    expect(events[1].output_tokens).toBe(647);
   });
 
   test("extracts project name from slug", () => {


### PR DESCRIPTION
Closes #13

## Summary

- **Root cause**: Claude Code writes one JSONL line per tool_use block for parallel calls. All share the same `message_id` but have distinct `tool_use_id`s. Deduplicating by `message_id` alone collapsed them to one row, silently dropping every parallel tool call except the last.
- **Fix**: Dedup key changed from `(message_id)` → `(message_id, tool_use_id)`. An "upgrade path" handles early streaming partials (no tool_use yet) by claiming the partial's row when its tool_use event arrives — so single-tool calls still produce exactly one DB row.
- **Also includes**: regression test for the parallel-agent scenario + full E2E test plan doc + cherry-picked fixes from `local-testing` (dedup final-vs-partial preference, data-wipe guard, tool_name recovery, custom_slug display, thinking-label priority).

## Changes

- `schema.ts` — `tool_use_id TEXT` column + index + backfill migration
- `parser.ts` — extract `toolUseId` from first `tool_use.id` block
- `queries.ts` — pass `tool_use_id` through `insertEvent`
- `processor.ts` — new dedup logic: exact match by `(message_id, tool_use_id)`, then upgrade path for early partials
- `processor.test.ts` — regression test: 3 JSONL lines (early partial + eng-1 partial + eng-2 final) → exactly 2 rows, both with correct `tool_use_id`
- `docs/regression-test-plan.md` — 7 scenario groups, 30+ test cases covering dedup, thinking display, session naming, agent timeline, SSE, ingestion edge cases

## Test plan

- [x] `bun test` — 117 tests pass
- [x] Docker restart + cursor reset on session `6a00f0f2` → event count went from 175 → 179, both `backend-eng-1` and `backend-eng-2` now present in DB with correct `tool_use_id`s
- [x] New sessions going forward will correctly show all parallel tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)