### PR TITLE
fix: session header event count, breadcrumb name, and server-side event search

### DIFF
--- a/docs/regression-test-plan.md
+++ b/docs/regression-test-plan.md
@@ -39,6 +39,25 @@ Playwright hits `http://localhost:<TEST_PORT>` and asserts DOM elements.
 | N2 | Session with only `slug` (no custom_slug) | Session list shows slug |
 | N3 | Session with neither slug | Session list shows first 8 chars of session ID |
 | N4 | Rename via UI → API sets custom_slug → page reload | Renamed slug persists across reload |
+| N5 | Rename a session → navigate to session detail page | Breadcrumb shows the new custom_slug, not the original slug |
+| N6 | Rename a session → return to project session list | Session row in the list shows the new custom_slug |
+
+### 3b. Project Naming
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| P1 | Project whose path-derived name contains dashes (e.g. `claude-telemetry`) | Project list and breadcrumb show the full derived name, not just the last segment after a dash |
+| P2 | Rename a project via API (`PATCH /api/projects/:id`) → reload project page | Project page heading and breadcrumb show new name |
+| P3 | Rename a project → navigate to a session within that project | Session detail page breadcrumb shows the updated project name (fetched from `GET /api/projects/:id`) |
+| P4 | Session detail page loads for a session whose project has a multi-word name | Breadcrumb segment reads the full `project.name`, not `project_id.split("-").pop()` |
+
+### 3c. Session Detail Header Stats
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| H1 | Navigate directly to a session detail page (GET `/api/sessions/:id`) | Header shows non-zero `event_count` matching the actual number of events in the DB |
+| H2 | Session detail header event count matches the total shown in the event table | Both numbers are identical for the same unfiltered session |
+| H3 | Session with 0 events (edge case) | Header shows `Events: 0`, not a blank/undefined value |
 
 ### 4. Event Table Display
 
@@ -58,6 +77,19 @@ Playwright hits `http://localhost:<TEST_PORT>` and asserts DOM elements.
 | A1 | Two agents spawned in parallel (D3 fixture) | AgentTimeline shows both agents in separate rows |
 | A2 | Agent spawns a sub-agent (nested sidechain) | Both parent and child visible; chain_id grouping correct |
 | A3 | Only 1 agent spawned | Only 1 agent row in timeline |
+
+### 5b. Agent Graph — Teammate Message Links
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| G1 | Team session with `<teammate-message teammate_id="X">` user events | Graph shows a dashed grey arrow from agent X to the receiving agent |
+| G2 | Multiple messages between the same pair of agents | A single dashed edge (deduplicated), not one edge per message |
+| G3 | `teammate_id="system"` in a message | No edge drawn for system sender |
+| G4 | Agent sending to itself (`agent_id` matches sender chain key) | No self-loop edge drawn |
+| G5 | Two agents with the same `agent_type` receiving a message | Dashed edge drawn to all matching nodes |
+| G6 | Session with no `<teammate-message>` events | Legend (`spawn` / `message`) is not shown |
+| G7 | Session with teammate messages present | Legend appears in bottom-left of the graph |
+| G8 | Both a spawn edge and a message edge exist between the same pair | Both edges visible: solid spawn + dashed message, offset sideways so they don't overlap |
 
 ### 6. SSE / Real-time Updates
 
@@ -114,6 +146,7 @@ test/fixtures/scenarios/
   n1-custom-slug.jsonl                # N1-N3: slug variations
   i4-git-worktree.jsonl               # I4: cwd with .worktrees/
   i5-subagent.jsonl                   # I5: isSidechain=true events
+  g1-teammate-messages.jsonl          # G1-G8: team session with <teammate-message> user events
 ```
 
 ---
@@ -125,6 +158,7 @@ test/fixtures/scenarios/
 3. **T1, T2** — thinking display correctness
 4. **A1** — agent timeline with parallel agents
 5. **E1–E4** — event table display
-6. **N1–N4** — session naming
-7. **S1, S2** — SSE (requires test server with file watcher)
-8. **I1–I6** — ingestion edge cases
+6. **N1–N6, P1–P4, H1–H3** — naming and header stats (covers project breadcrumb, session rename, event count regressions)
+7. **G1–G8** — agent graph teammate message links
+8. **S1, S2** — SSE (requires test server with file watcher)
+9. **I1–I6** — ingestion edge cases

--- a/docs/regression-test-plan.md
+++ b/docs/regression-test-plan.md
@@ -67,8 +67,9 @@ Playwright hits `http://localhost:<TEST_PORT>` and asserts DOM elements.
 | E2 | `user` event with tool result content | Row shows correct user label |
 | E3 | `system` event | Row shows "system" label |
 | E4 | `progress` events hidden by default | No progress rows visible unless filter enabled |
-| E5 | Search by tool name | Only matching rows visible |
+| E5 | Search by tool name — results span entire session (not just current page) | Matching events from all pages returned; searching "skill" finds events beyond the first loaded page |
 | E6 | Filter by agent | Only events for selected agent visible |
+| E7 | Search in session event viewer returns same results as raw explorer search for same query | Both use server-side FTS5; result counts match |
 
 ### 5. Agent Timeline / Parallel Agents
 

--- a/src/client/components/AgentGraph.tsx
+++ b/src/client/components/AgentGraph.tsx
@@ -25,6 +25,7 @@ interface GraphLink {
   tokens: number;
   lastActiveAt: number; // timestamp ms
   color: string;
+  linkType: "spawn" | "message";
 }
 
 interface Transform {
@@ -161,7 +162,65 @@ export function AgentGraph({ agents, events }: { agents: Agent[]; events: Event[
         : MAIN_COLOR;
 
       const totalTokens = members.reduce((s, a) => s + (a.total_tokens || (agentTokens.get(a.id) ?? 0)), 0);
-      links.push({ source: sourceId, target: chainKey, tokens: totalTokens, lastActiveAt: lastActive, color });
+      links.push({ source: sourceId, target: chainKey, tokens: totalTokens, lastActiveAt: lastActive, color, linkType: "spawn" });
+    });
+
+    // Build teammate message links from <teammate-message> user events
+    // Map agent_type → chain keys (one type may match multiple chains if agents were restarted/duplicated)
+    const agentTypeToChainKeys = new Map<string, string[]>();
+    groups.forEach((members, chainKey) => {
+      const agentType = members[0].agent_type;
+      if (!agentType) return;
+      const existing = agentTypeToChainKeys.get(agentType) ?? [];
+      existing.push(chainKey);
+      agentTypeToChainKeys.set(agentType, existing);
+    });
+
+    // agent_id → chain key for receiver lookup
+    const agentIdToChainKey = new Map<string, string>();
+    agents.forEach((a) => {
+      agentIdToChainKey.set(a.id, a.chain_id ?? a.id);
+    });
+
+    // Collect unique (sender chain key → receiver chain key) pairs from teammate message events
+    const messagePairs = new Set<string>();
+    const messageLastActive = new Map<string, number>();
+    const TEAMMATE_MSG_RE = /<teammate-message[^>]*teammate_id="([^"]+)"/g;
+
+    for (const e of events) {
+      if (e.type !== "user" || !e.content?.startsWith("<teammate-message")) continue;
+      const receiverChainKey = e.agent_id ? agentIdToChainKey.get(e.agent_id) : "__main__";
+      if (!receiverChainKey) continue;
+
+      const ts = new Date(e.timestamp).getTime();
+      let match: RegExpExecArray | null;
+      TEAMMATE_MSG_RE.lastIndex = 0;
+      while ((match = TEAMMATE_MSG_RE.exec(e.content)) !== null) {
+        const senderId = match[1];
+        if (senderId === "system") continue;
+
+        const senderChainKeys = agentTypeToChainKeys.get(senderId) ?? [];
+        for (const senderChainKey of senderChainKeys) {
+          if (senderChainKey === receiverChainKey) continue; // skip self-loops
+          const pairKey = `${senderChainKey}→${receiverChainKey}`;
+          messagePairs.add(pairKey);
+          const prev = messageLastActive.get(pairKey) ?? 0;
+          if (ts > prev) messageLastActive.set(pairKey, ts);
+        }
+      }
+    }
+
+    const MESSAGE_COLOR = "#94a3b8"; // neutral slate — distinct from spawn links
+    messagePairs.forEach((pairKey) => {
+      const [senderChainKey, receiverChainKey] = pairKey.split("→");
+      links.push({
+        source: senderChainKey,
+        target: receiverChainKey,
+        tokens: 0,
+        lastActiveAt: messageLastActive.get(pairKey) ?? now,
+        color: MESSAGE_COLOR,
+        linkType: "message",
+      });
     });
 
     return { nodes, links, maxTokens };
@@ -441,9 +500,10 @@ export function AgentGraph({ agents, events }: { agents: Agent[]; events: Event[
         style={{ cursor: panRef.current ? "grabbing" : "grab" }}
       >
         <defs>
-          {/* Arrow markers per link color */}
+          {/* Arrow markers per link */}
           {links.map((link) => {
-            const markerId = `arrow-${link.source}-${link.target}`;
+            const markerId = `arrow-${link.linkType}-${link.source}-${link.target}`;
+            const thickness = link.linkType === "message" ? 2 : linkThickness(link.tokens);
             return (
               <marker
                 key={markerId}
@@ -452,8 +512,8 @@ export function AgentGraph({ agents, events }: { agents: Agent[]; events: Event[
                 refX="0"
                 refY="3"
                 markerUnits="userSpaceOnUse"
-                markerWidth={Math.max(8, linkThickness(link.tokens) * 2)}
-                markerHeight={Math.max(8, linkThickness(link.tokens) * 2) * 0.6}
+                markerWidth={Math.max(8, thickness * 2)}
+                markerHeight={Math.max(8, thickness * 2) * 0.6}
                 orient="auto"
               >
                 <path d="M 0 0 L 10 3 L 0 6 Z" fill={fadedColor(link.color, link.lastActiveAt)} />
@@ -464,7 +524,7 @@ export function AgentGraph({ agents, events }: { agents: Agent[]; events: Event[
 
         <g transform={`translate(${transform.x}, ${transform.y}) scale(${transform.scale})`}>
           {/* Links */}
-          {links.map((link, i) => {
+          {links.map((link) => {
             const sourcePos = nodePositions.get(link.source);
             const targetPos = nodePositions.get(link.target);
             if (!sourcePos || !targetPos) return null;
@@ -480,21 +540,27 @@ export function AgentGraph({ agents, events }: { agents: Agent[]; events: Event[
             if (dist === 0) return null;
             const nx = dx / dist;
             const ny = dy / dist;
-            // markerUnits="userSpaceOnUse" + refX="0": tip protrudes markerWidth px
-            // beyond the line endpoint. markerWidth = max(8, thickness*2).
-            const thickness = linkThickness(link.tokens);
+
+            const isMessage = link.linkType === "message";
+            // Message links use a fixed thin stroke; spawn links use token-proportional thickness
+            const thickness = isMessage ? 2 : linkThickness(link.tokens);
             const markerLen = Math.max(8, thickness * 2);
+            // Offset message links slightly sideways so they don't overlap spawn edges
+            const perpX = isMessage ? -ny * 4 : 0;
+            const perpY = isMessage ? nx * 4 : 0;
+            const markerId = `arrow-${link.linkType}-${link.source}-${link.target}`;
 
             return (
               <line
-                key={`${link.source}-${link.target}`}
-                x1={sourcePos.x + nx * rSource}
-                y1={sourcePos.y + ny * rSource}
-                x2={targetPos.x - nx * (rTarget + markerLen)}
-                y2={targetPos.y - ny * (rTarget + markerLen)}
+                key={`${link.linkType}-${link.source}-${link.target}`}
+                x1={sourcePos.x + nx * rSource + perpX}
+                y1={sourcePos.y + ny * rSource + perpY}
+                x2={targetPos.x - nx * (rTarget + markerLen) + perpX}
+                y2={targetPos.y - ny * (rTarget + markerLen) + perpY}
                 stroke={fadedColor(link.color, link.lastActiveAt)}
-                strokeWidth={linkThickness(link.tokens)}
-                markerEnd={`url(#arrow-${link.source}-${link.target})`}
+                strokeWidth={thickness}
+                strokeDasharray={isMessage ? "6 4" : undefined}
+                markerEnd={`url(#${markerId})`}
               />
             );
           })}
@@ -565,6 +631,20 @@ export function AgentGraph({ agents, events }: { agents: Agent[]; events: Event[
             <div>Events: {tooltip.node.eventCount}</div>
             <div>Tokens: {formatTokens(tooltip.node.tokens, formatOpts)}</div>
           </div>
+        </div>
+      )}
+
+      {/* Legend */}
+      {links.some((l) => l.linkType === "message") && (
+        <div className="absolute bottom-2 left-2 flex items-center gap-3 text-xs text-[#64748b] bg-white/90 px-3 py-1.5 rounded border border-border">
+          <span className="flex items-center gap-1.5">
+            <svg width="24" height="8"><line x1="0" y1="4" x2="24" y2="4" stroke="#003864" strokeWidth="2"/><path d="M20 1 L24 4 L20 7 Z" fill="#003864"/></svg>
+            spawn
+          </span>
+          <span className="flex items-center gap-1.5">
+            <svg width="24" height="8"><line x1="0" y1="4" x2="24" y2="4" stroke="#94a3b8" strokeWidth="2" strokeDasharray="5 3"/><path d="M20 1 L24 4 L20 7 Z" fill="#94a3b8"/></svg>
+            message
+          </span>
         </div>
       )}
 

--- a/src/client/components/AgentTimeline.tsx
+++ b/src/client/components/AgentTimeline.tsx
@@ -109,21 +109,24 @@ export function AgentTimeline({
 
   // Debounce visible agents -> agentIds filter (150ms to batch rapid show/hide-all clicks)
   const debouncedVisibleAgents = useDebouncedValue(visibleAgents, 150);
+  const debouncedSearch = useDebouncedValue(searchInput, 300);
 
   const hookFilters = useMemo(() => {
     const allChainKeys = new Set(agentSummaries.map(getChainKey));
     const allVisible = [...allChainKeys].every(key => debouncedVisibleAgents.has(key));
+    const searchOpt = debouncedSearch ? { search: debouncedSearch } : {};
 
     if (allVisible) {
       // No agentIds filter - return all events for this session
-      return { sessionId };
+      return { sessionId, ...searchOpt };
     }
 
     return {
       sessionId,
       agentIds: [...debouncedVisibleAgents] as (string | null)[],
+      ...searchOpt,
     };
-  }, [sessionId, debouncedVisibleAgents, agentSummaries]);
+  }, [sessionId, debouncedVisibleAgents, agentSummaries, debouncedSearch]);
 
   const {
     events: hookEvents,
@@ -281,7 +284,6 @@ export function AgentTimeline({
           </div>
           <EventTable
             events={hookEvents}
-            searchQuery={searchInput}
             total={total}
             isLoading={isLoading}
             onLoadMore={loadMore}

--- a/src/client/pages/SessionDetailPage.tsx
+++ b/src/client/pages/SessionDetailPage.tsx
@@ -8,13 +8,14 @@ import { CostBreakdownPanel } from "../components/CostBreakdownPanel";
 import { useSSE } from "../lib/sse";
 import { useToast } from "../hooks/useToast";
 import { formatTokens, formatCost, cn } from "../lib/utils";
-import type { Session, Event, Agent, CostBreakdown, AgentSummary } from "../lib/types";
+import type { Session, Event, Agent, CostBreakdown, AgentSummary, Project } from "../lib/types";
 
 type Tab = "agents" | "graph-trace";
 
 export function SessionDetailPage() {
   const { id } = useParams<{ id: string }>();
   const [session, setSession] = useState<Session | null>(null);
+  const [project, setProject] = useState<Project | null>(null);
   const [agentSummaries, setAgentSummaries] = useState<AgentSummary[]>([]);
   const [costs, setCosts] = useState<CostBreakdown[]>([]);
   const [tab, setTab] = useState<Tab>("agents");
@@ -31,14 +32,16 @@ export function SessionDetailPage() {
 
   const fetchCore = useCallback(async () => {
     if (!id) return;
-    const [sess, summaries, costData] = await Promise.all([
-      api.sessions.get(id),
+    const sess = await api.sessions.get(id);
+    setSession(sess);
+    const [summaries, costData, proj] = await Promise.all([
       api.sessions.agentSummaries(id),
       api.sessions.costs(id).catch(() => [] as CostBreakdown[]),
+      api.projects.get(sess.project_id).catch(() => null),
     ]);
-    setSession(sess);
     setAgentSummaries(summaries);
     setCosts(costData);
+    setProject(proj);
     setLive(true);
   }, [id]);
 
@@ -134,7 +137,7 @@ export function SessionDetailPage() {
         <Link to="/" className="hover:text-primary">Projects</Link>
         <span>/</span>
         <Link to={`/projects/${encodeURIComponent(session.project_id)}`} className="hover:text-primary">
-          {session.project_id.split("-").pop()}
+          {project?.name ?? session.project_id.split("/").pop() ?? session.project_id}
         </Link>
         <span>/</span>
         <span className="text-primary-dark font-medium">{

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -253,7 +253,13 @@ export function listSessions(db: Database, projectId: string) {
 }
 
 export function getSession(db: Database, id: string) {
-  return db.query("SELECT * FROM sessions WHERE id = ?").get(id);
+  return db.query(`
+    SELECT s.*,
+      (SELECT COUNT(*) FROM agents WHERE session_id = s.id) as agent_count,
+      (SELECT COUNT(*) FROM events WHERE session_id = s.id) as event_count,
+      (SELECT MAX(timestamp) FROM events WHERE session_id = s.id) as last_updated
+    FROM sessions s WHERE s.id = ?
+  `).get(id);
 }
 
 export function listEvents(


### PR DESCRIPTION
## Summary

- **`getSession` missing computed columns**: `event_count`, `agent_count`, and `last_updated` were only returned by `listSessions` (subqueries), not the single-session endpoint — causing the Events stat to render blank in the session detail header
- **Breadcrumb shows proper project name**: session detail page now fetches `project.name` instead of splitting `project_id` on dashes (which truncated e.g. `claude-telemetry` to `telemetry`)
- **Agent graph teammate links**: visualises `SendMessage` tool calls as dashed edges between agents
- **Event viewer search is now server-side FTS5**: `AgentTimeline` was passing the search term only to `EventTable` for client-side filtering of the loaded page; now passes it into `useInfiniteEvents` so the full FTS5 index is searched (same as Raw Explorer)

## Test plan

- [ ] Session detail page shows non-blank Events count in header
- [ ] Breadcrumb shows full project name (e.g. `claude-telemetry`, not `telemetry`)
- [ ] Searching "skill" in session event viewer returns matching events across all pages, not just the first loaded page
- [ ] Agent graph shows dashed edges for teammate message links where applicable
- [ ] Regression scenarios H1–H3, E5, E7 added to `docs/regression-test-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)