### PR TITLE
feat: dark mode with animated sun/moon toggle

### DIFF
--- a/src/client/components/AgentGraph.tsx
+++ b/src/client/components/AgentGraph.tsx
@@ -488,7 +488,7 @@ export function AgentGraph({ agents, events }: { agents: Agent[]; events: Event[
   return (
     <div
       ref={containerRef}
-      className="relative border border-border rounded-xl bg-white overflow-hidden"
+      className="relative border border-border rounded-xl bg-bg overflow-hidden"
       style={{ minHeight: 1000 }}
     >
       <svg
@@ -660,7 +660,7 @@ export function AgentGraph({ agents, events }: { agents: Agent[]; events: Event[
       {/* Tooltip */}
       {tooltip && (
         <div
-          className="absolute z-50 pointer-events-none rounded-lg border border-border bg-white px-3 py-2 shadow-lg text-xs"
+          className="absolute z-50 pointer-events-none rounded-lg border border-border bg-surface px-3 py-2 shadow-lg text-xs"
           style={{ left: tooltip.x, top: tooltip.y }}
         >
           <div className="font-semibold text-[#003864] mb-1">{tooltip.node.label}</div>
@@ -675,7 +675,7 @@ export function AgentGraph({ agents, events }: { agents: Agent[]; events: Event[
 
       {/* Legend */}
       {links.length > 0 && (
-        <div className="absolute bottom-2 left-2 flex items-center gap-3 text-xs text-[#64748b] bg-white/90 px-3 py-1.5 rounded border border-border">
+        <div className="absolute bottom-2 left-2 flex items-center gap-3 text-xs text-muted bg-bg/90 px-3 py-1.5 rounded border border-border">
           <span className="flex items-center gap-1.5">
             <svg width="24" height="8"><line x1="0" y1="4" x2="24" y2="4" stroke="#003864" strokeWidth="2"/><path d="M20 1 L24 4 L20 7 Z" fill="#003864"/></svg>
             agent connection
@@ -685,7 +685,7 @@ export function AgentGraph({ agents, events }: { agents: Agent[]; events: Event[
 
       {/* Zoom indicator */}
       {transform.scale !== 1 && (
-        <div className="absolute bottom-2 right-2 text-xs text-[#64748b] bg-white/80 px-2 py-0.5 rounded border border-border">
+        <div className="absolute bottom-2 right-2 text-xs text-muted bg-bg/80 px-2 py-0.5 rounded border border-border">
           {Math.round(transform.scale * 100)}%
         </div>
       )}

--- a/src/client/components/AgentTimeline.tsx
+++ b/src/client/components/AgentTimeline.tsx
@@ -231,7 +231,7 @@ export function AgentTimeline({
               key={s.chainKey ?? "__main__"}
               onClick={() => toggleAgent(s.chainKey)}
               className={cn(
-                "border rounded-xl bg-white p-3 flex flex-col gap-1 cursor-pointer transition-all select-none",
+                "border rounded-xl bg-bg p-3 flex flex-col gap-1 cursor-pointer transition-all select-none",
                 active ? "border-primary/40 shadow-sm" : "border-border opacity-50",
                 "hover:shadow-md"
               )}
@@ -279,7 +279,7 @@ export function AgentTimeline({
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
               placeholder="Filter events by tool, content, agent..."
-              className="w-full border border-border rounded-lg px-3 py-1.5 text-sm bg-white"
+              className="w-full border border-border rounded-lg px-3 py-1.5 text-sm bg-surface"
             />
           </div>
           <EventTable

--- a/src/client/components/CostBreakdownPanel.tsx
+++ b/src/client/components/CostBreakdownPanel.tsx
@@ -40,7 +40,7 @@ export function CostBreakdownPanel({
   const totalTokens = totalInputTokens + totalOutputTokens + totalCacheRead + totalCacheCreation;
 
   return (
-    <div className="border border-border rounded-xl bg-white p-4 mb-6">
+    <div className="border border-border rounded-xl bg-bg p-4 mb-6">
       {/* Top row: total cost + total tokens */}
       <div className="flex items-baseline gap-8 mb-3">
         <div>

--- a/src/client/components/DetailPanel.tsx
+++ b/src/client/components/DetailPanel.tsx
@@ -21,7 +21,7 @@ export function DetailPanel({ event, onClose }: { event: Event | null; onClose: 
   } catch { content = []; }
 
   return (
-    <div className="border border-border rounded-xl bg-white flex flex-col max-h-[calc(100vh-8rem)] overflow-hidden">
+    <div className="border border-border rounded-xl bg-bg flex flex-col max-h-[calc(100vh-8rem)] overflow-hidden">
       <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
         <h3 className="font-semibold text-primary-dark">Event Detail</h3>
         <button onClick={onClose} className="text-muted hover:text-primary-dark text-xl">&times;</button>

--- a/src/client/components/ProjectCard.tsx
+++ b/src/client/components/ProjectCard.tsx
@@ -52,7 +52,7 @@ export function ProjectCard({ project, onUpdated }: { project: Project; onUpdate
 
   if (editing) {
     return (
-      <div className="block border border-primary/40 rounded-xl p-5 bg-white shadow-md">
+      <div className="block border border-primary/40 rounded-xl p-5 bg-bg shadow-md">
         <div className="space-y-3 mb-4">
           <div>
             <label className="text-xs text-muted block mb-1">Name</label>
@@ -96,7 +96,7 @@ export function ProjectCard({ project, onUpdated }: { project: Project; onUpdate
     <div className="relative group">
       <Link
         to={`/projects/${encodeURIComponent(project.id)}`}
-        className="block border border-border rounded-xl p-5 hover:border-primary/40 hover:shadow-md transition-all duration-200 bg-white"
+        className="block border border-border rounded-xl p-5 hover:border-primary/40 hover:shadow-md transition-all duration-200 bg-bg"
       >
         <div className="flex items-start justify-between mb-3">
           <div className="flex items-center gap-1.5 min-w-0">

--- a/src/client/components/RawExplorer.tsx
+++ b/src/client/components/RawExplorer.tsx
@@ -70,7 +70,7 @@ export function RawExplorer() {
           <select
             value={typeFilter}
             onChange={(e) => setTypeFilter(e.target.value)}
-            className="border border-border rounded-lg px-3 py-1.5 text-sm bg-white"
+            className="border border-border rounded-lg px-3 py-1.5 text-sm bg-surface"
           >
             <option value="">All types</option>
             <option value="assistant">Assistant</option>
@@ -81,7 +81,7 @@ export function RawExplorer() {
           <select
             value={modelFilter}
             onChange={(e) => setModelFilter(e.target.value)}
-            className="border border-border rounded-lg px-3 py-1.5 text-sm bg-white"
+            className="border border-border rounded-lg px-3 py-1.5 text-sm bg-surface"
           >
             <option value="">All models</option>
             <option value="claude-opus-4-6">Opus</option>

--- a/src/client/components/Toast.tsx
+++ b/src/client/components/Toast.tsx
@@ -40,7 +40,7 @@ export function ToastContainer() {
       {toasts.map((toast) => (
         <div
           key={toast.id}
-          className="pointer-events-auto flex items-center gap-3 bg-white border border-border rounded-xl shadow-lg px-4 py-3 cursor-pointer hover:border-primary transition-all animate-slide-in-right max-w-sm"
+          className="pointer-events-auto flex items-center gap-3 bg-surface border border-border rounded-xl shadow-lg px-4 py-3 cursor-pointer hover:border-primary transition-all animate-slide-in-right max-w-sm"
           onClick={() => { navigate(`/sessions/${toast.sessionId}`); dismiss(toast.id); }}
           role="button"
         >

--- a/src/client/components/layout/Shell.tsx
+++ b/src/client/components/layout/Shell.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useState } from "react";
 import { Outlet, NavLink } from "react-router-dom";
 import { cn } from "../../lib/utils";
 import { ToastContainer } from "../Toast";
+import { useSettings } from "../../contexts/SettingsContext";
 
 const navItems = [
   { to: "/", label: "Projects", icon: "M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" },
@@ -8,11 +10,158 @@ const navItems = [
   { to: "/settings", label: "Settings", icon: "M12 15a3 3 0 100-6 3 3 0 000 6z M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" },
 ];
 
+function readDarkFromStorage(): boolean {
+  try { return localStorage.getItem("ct-dark-mode") === "true"; } catch { return false; }
+}
+
+function applyDark(enabled: boolean) {
+  document.documentElement.classList.toggle("dark", enabled);
+  try { localStorage.setItem("ct-dark-mode", String(enabled)); } catch {}
+}
+
+function DarkModeIcon({ dark }: { dark: boolean }) {
+  const t = "transition: opacity 0.35s ease, transform 0.45s ease";
+  return (
+    <svg width="20" height="20" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ flexShrink: 0 }}>
+      <defs>
+        <radialGradient id="dm-sun" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="#ffe066" />
+          <stop offset="100%" stopColor="#ffaa00" />
+        </radialGradient>
+        <radialGradient id="dm-moon" cx="40%" cy="35%" r="60%">
+          <stop offset="0%" stopColor="#c8d8f8" />
+          <stop offset="100%" stopColor="#a0b4e8" />
+        </radialGradient>
+        <filter id="dm-glow">
+          <feGaussianBlur stdDeviation="1.8" result="b" />
+          <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+        </filter>
+        <filter id="dm-rays">
+          <feGaussianBlur stdDeviation="0.8" result="b" />
+          <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+        </filter>
+      </defs>
+
+      {/* Sky background */}
+      <circle
+        cx="22" cy="22" r="20"
+        style={{
+          fill: dark ? "#bfdbfe" : "#0f172a",
+          transition: "fill 0.5s ease",
+        }}
+      />
+
+      {/* Stars — visible in dark/moon mode */}
+      {([
+        [10, 9, 0.9], [33, 7, 0.7], [36, 16, 0.5], [8, 18, 0.6], [30, 32, 0.8], [14, 33, 0.5],
+      ] as [number, number, number][]).map(([cx, cy, r], i) => (
+        <circle
+          key={i} cx={cx} cy={cy} r={r} fill="white"
+          style={{
+            opacity: dark ? 0 : 0.85,
+            transition: `opacity 0.3s ease ${i * 40}ms`,
+          }}
+        />
+      ))}
+
+      {/* Sun rays — visible in light/sun mode */}
+      <g
+        transform="translate(22,22)"
+        style={{
+          opacity: dark ? 1 : 0,
+          transform: `translate(22px,22px) rotate(${dark ? 0 : -45}deg)`,
+          transition: "opacity 0.35s ease 0.1s, transform 0.45s ease",
+          filter: "url(#dm-rays)",
+        }}
+      >
+        {[0, 45, 90, 135, 180, 225, 270, 315].map((angle) => {
+          const rad = (angle * Math.PI) / 180;
+          return (
+            <line
+              key={angle}
+              x1={Math.cos(rad) * 13} y1={Math.sin(rad) * 13}
+              x2={Math.cos(rad) * 16.5} y2={Math.sin(rad) * 16.5}
+              stroke="#ffcc00" strokeWidth="2" strokeLinecap="round"
+              opacity={angle % 90 === 0 ? 0.9 : 0.65}
+            />
+          );
+        })}
+      </g>
+
+      {/* Moon crescent */}
+      <g style={{
+        opacity: dark ? 0 : 1,
+        transform: dark ? "translate(3px, -3px) scale(0.85)" : "translate(0,0) scale(1)",
+        transition: "opacity 0.3s ease, transform 0.45s ease",
+        transformOrigin: "22px 22px",
+      }}>
+        <circle cx="22" cy="22" r="9" fill="url(#dm-moon)" filter="url(#dm-glow)" />
+        <circle
+          cx="26" cy="19" r="7.5"
+          style={{
+            fill: dark ? "#bfdbfe" : "#0f172a",
+            transition: "fill 0.5s ease",
+          }}
+        />
+        <circle cx="18" cy="24" r="1.2" fill="#c8d8f8" opacity="0.5" />
+        <circle cx="21" cy="19" r="0.8" fill="#c8d8f8" opacity="0.4" />
+        <circle cx="16" cy="20" r="0.6" fill="#c8d8f8" opacity="0.35" />
+      </g>
+
+      {/* Sun disc */}
+      <circle
+        cx="22" cy="22" r="8.5"
+        fill="url(#dm-sun)"
+        style={{
+          opacity: dark ? 1 : 0,
+          transform: dark ? "scale(1)" : "scale(0.6)",
+          transition: "opacity 0.35s ease 0.1s, transform 0.45s ease 0.1s",
+          transformOrigin: "22px 22px",
+          filter: "url(#dm-glow)",
+        }}
+      />
+
+      {/* Cloud — floats in when switching to light/sun mode */}
+      <g style={{
+        opacity: dark ? 0.85 : 0,
+        transform: dark ? "translateX(0)" : "translateX(7px)",
+        transition: "opacity 0.5s ease 0.25s, transform 0.55s ease 0.25s",
+      }}>
+        <ellipse cx="30" cy="34" rx="5.5" ry="3.2" fill="white" opacity="0.92" />
+        <ellipse cx="27.5" cy="35.5" rx="3.5" ry="2.3" fill="white" opacity="0.92" />
+        <ellipse cx="33" cy="35.5" rx="3.2" ry="2" fill="white" opacity="0.88" />
+        <ellipse cx="30" cy="36.5" rx="5" ry="1.8" fill="white" opacity="0.95" />
+      </g>
+    </svg>
+  );
+}
+
 export function Shell() {
+  const { settings, updateSettings, isLoading } = useSettings();
+  const [dark, setDark] = useState(readDarkFromStorage);
+
+  // Sync from server settings once loaded
+  useEffect(() => {
+    if (!isLoading) {
+      const serverDark = !!(settings["display.darkMode"] ?? false);
+      setDark(serverDark);
+      applyDark(serverDark);
+    }
+  }, [isLoading]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const toggleDark = () => {
+    const next = !dark;
+    setDark(next);
+    applyDark(next);
+    updateSettings({ "display.darkMode": next });
+  };
+
   return (
     <div className="min-h-screen flex">
       <ToastContainer />
-      <nav className="w-56 bg-surface border-r border-border flex flex-col py-4 px-3 shrink-0">
+
+      {/* Sticky sidebar — always viewport-height regardless of page content */}
+      <nav className="w-56 bg-surface border-r border-border flex flex-col py-4 px-3 shrink-0 sticky top-0 h-screen overflow-y-auto">
         <div className="flex items-center gap-2.5 px-3 mb-8">
           <svg width="30" height="30" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
             <defs>
@@ -51,6 +200,7 @@ export function Shell() {
           </svg>
           <span className="font-semibold text-primary-dark text-sm tracking-tight">Claude Telemetry</span>
         </div>
+
         {navItems.map((item) => (
           <NavLink
             key={item.to}
@@ -69,7 +219,19 @@ export function Shell() {
             {item.label}
           </NavLink>
         ))}
+
+        <div className="flex-1" />
+
+        <button
+          onClick={toggleDark}
+          title={dark ? "Switch to light mode" : "Switch to dark mode"}
+          className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors text-muted hover:bg-primary/5 hover:text-primary-dark w-full"
+        >
+          <DarkModeIcon dark={dark} />
+          <span>{dark ? "Light mode" : "Dark mode"}</span>
+        </button>
       </nav>
+
       <main className="flex-1 p-6 overflow-auto">
         <Outlet />
       </main>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <script>try{if(localStorage.getItem('ct-dark-mode')==='true')document.documentElement.classList.add('dark')}catch(e){}</script>
 </head>
 <body>
   <div id="root"></div>

--- a/src/client/pages/settings/PricingTab.tsx
+++ b/src/client/pages/settings/PricingTab.tsx
@@ -160,7 +160,7 @@ export function PricingTab() {
                 </button>
                 <button
                   onClick={() => { setAdding(false); setErrors((prev) => { const n = { ...prev }; delete n["new-model-name"]; return n; }); }}
-                  className="bg-white text-muted border border-border px-3 py-1.5 rounded-lg text-sm hover:text-primary-dark"
+                  className="bg-bg text-muted border border-border px-3 py-1.5 rounded-lg text-sm hover:text-primary-dark"
                 >
                   Cancel
                 </button>
@@ -224,7 +224,7 @@ export function PricingTab() {
         <div className="flex gap-2 shrink-0 ml-3">
           <button
             onClick={reset}
-            className="bg-white text-muted border border-border px-4 py-1.5 rounded-lg text-sm hover:text-primary-dark hover:border-primary-dark"
+            className="bg-bg text-muted border border-border px-4 py-1.5 rounded-lg text-sm hover:text-primary-dark hover:border-primary-dark"
           >
             Reset to Defaults
           </button>

--- a/src/client/styles/globals.css
+++ b/src/client/styles/globals.css
@@ -19,6 +19,22 @@ body {
   color: var(--color-primary-dark);
 }
 
+html.dark {
+  --color-bg: #141414;
+  --color-surface: #1f1f1f;
+  --color-border: #2d2d2d;
+  --color-muted: #8b8fa8;
+  --color-primary-dark: #e2e8f0;
+}
+
+html.dark input,
+html.dark textarea,
+html.dark select {
+  background-color: var(--color-surface);
+  color: var(--color-primary-dark);
+  color-scheme: dark;
+}
+
 @keyframes slideIn {
   from { transform: translateX(100%); }
   to { transform: translateX(0); }

--- a/src/shared/settings-defaults.ts
+++ b/src/shared/settings-defaults.ts
@@ -126,6 +126,11 @@ export const SETTINGS_REGISTRY: Record<string, SettingDefinition> = {
     type: "number", defaultValue: 100, min: 50, max: 2000,
     tooltip: "How often to check whether a file has finished writing (ms). Used during the stability wait period.",
   },
+  "display.darkMode": {
+    type: "boolean",
+    defaultValue: false,
+    tooltip: "Enable dark mode. Also toggleable from the sidebar.",
+  },
   "display.maxLoadedEvents": {
     type: "number", defaultValue: 2000, min: 50, max: 50000,
     tooltip: "Maximum events held in memory while scrolling. When this limit is exceeded, the oldest events are trimmed from the buffer to free memory. Higher values let you scroll further without reloading, but use more browser memory.",


### PR DESCRIPTION
## Summary

- Charcoal dark theme (`#141414` bg / `#1f1f1f` surface / `#2d2d2d` borders) toggled from the sidebar nav
- Animated SVG icon: moon+stars fades into sun+rays+cloud with CSS transitions
- Persisted to `localStorage` for zero-flash on load, and synced to the settings backend (`display.darkMode`)
- All `bg-white` hardcodes replaced with semantic `bg-bg`/`bg-surface` tokens so the entire UI responds to the theme
- Sidebar nav is now `sticky` + `h-screen` so the toggle is always visible regardless of page content length

## Test plan

- [ ] Toggle dark mode from sidebar — icon animates, theme switches instantly
- [ ] Reload page — dark mode persists (no flash)
- [ ] Navigate to Projects, Project Detail, Session Detail, Raw Explorer, Settings — toggle always visible in sidebar
- [ ] All panels, cards, inputs, tooltips, graph overlays render correctly in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)