### PR TITLE
fix: price current models and stop silent $0 costs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,22 @@ Follow `docs/superpowers/plans/2026-03-18-claude-telemetry-dashboard.md` — 20 
 | `CT_OTEL_ENABLED` | `false` | Enable OTEL HTTP receiver |
 | `CLAUDE_HOME` | `~/.claude` | Host path for Docker volume mounts |
 
+## Deployment
+
+The dashboard runs as a **single Docker container** (`docker-compose.yml`), served on host port **4242** (→ container `3000`).
+
+```bash
+docker compose up -d --build   # apply code changes: rebuild image + recreate container
+docker compose logs -f claude-telemetry   # tail server logs (ingestion, pricing migrations)
+docker compose ps              # check container status
+curl -s http://localhost:4242/api/projects   # verify API / inspect live data
+```
+
+- **Live database** lives in the named volume `telemetry-db` at `/data/db/telemetry.db` **inside the container** — it persists across rebuilds. The `./telemetry.db` on the host is stale `bun scripts/seed.ts` output, **not** the running instance's DB.
+- **Project logs** are mounted **read-only** from `${CLAUDE_HOME}/projects` → `/data/projects`. The container watches them and ingests incrementally; source JSONL is never modified.
+- **Applying code changes requires `--build`** — a plain `up -d`/`restart` reuses the old image. After rebuild, startup migrations in `schema.ts` and `pricing-migration.ts` run once against the volume DB.
+- **Data caveat:** older projects' JSONL may no longer exist on disk — their history survives only in the volume DB. Do **not** wipe/re-seed the DB to "refresh"; recompute in place from stored data instead.
+
 ## Agent Strategy
 
 - Use agent teams liberally by using the `TeamCreate` tool

--- a/src/server/db/pricing-migration.ts
+++ b/src/server/db/pricing-migration.ts
@@ -1,0 +1,91 @@
+// src/server/db/pricing-migration.ts
+import type { Database } from "bun:sqlite";
+import { PRICING_VERSION, calculateCost } from "../../shared/pricing";
+import { getSetting } from "./settings";
+import { updateSessionAggregates } from "./queries";
+
+// Prefixed migration_ so getAllSettings() excludes it from the settings API surface.
+const RECOMPUTE_KEY = "migration_pricing_recompute";
+
+/**
+ * Recompute stored cost aggregates when the pricing table has changed since the
+ * last run. Session/project costs are derived from per-event tokens × pricing,
+ * but sessions.total_cost_usd is only refreshed when a session receives a new
+ * event — so a pricing change (e.g. adding a model that was previously $0)
+ * leaves historical sessions stale until touched. This runs a one-time
+ * re-aggregation, keyed to PRICING_VERSION, so it fires exactly once per
+ * pricing change and is a no-op on every other startup.
+ *
+ * Recomputes purely from data already in the DB (event tokens) — it never reads
+ * JSONL, so it is safe even for projects whose source logs are no longer on disk.
+ *
+ * MUST be called AFTER loadPricingFromSettings() so DB pricing overrides are
+ * respected.
+ */
+export function recomputePricingIfChanged(db: Database): void {
+  const stored = getSetting(db, RECOMPUTE_KEY);
+  if (stored === PRICING_VERSION) return;
+
+  const startedAt = performance.now();
+
+  // 1) Refresh per-event stored cost_usd for every event with a model + tokens.
+  //    (Aggregation below doesn't read this column, but keep it consistent for
+  //    any consumer that does — e.g. the watcher's NULL-cost backfill.)
+  const eventRows = db
+    .query(
+      `SELECT rowid, model,
+              COALESCE(input_tokens,0)          AS input_tokens,
+              COALESCE(output_tokens,0)         AS output_tokens,
+              COALESCE(cache_read_tokens,0)     AS cache_read_tokens,
+              COALESCE(cache_creation_tokens,0) AS cache_creation_tokens
+       FROM events
+       WHERE model IS NOT NULL`,
+    )
+    .all() as Array<{
+    rowid: number;
+    model: string;
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_tokens: number;
+    cache_creation_tokens: number;
+  }>;
+
+  const updateCost = db.prepare("UPDATE events SET cost_usd = ? WHERE rowid = ?");
+  const recomputeEvents = db.transaction((rows: typeof eventRows) => {
+    for (const row of rows) {
+      const cost = calculateCost(row.model, {
+        inputTokens: row.input_tokens,
+        outputTokens: row.output_tokens,
+        cacheReadTokens: row.cache_read_tokens,
+        cacheCreationTokens: row.cache_creation_tokens,
+      });
+      updateCost.run(cost, row.rowid);
+    }
+  });
+  recomputeEvents(eventRows);
+
+  // 2) Re-aggregate every session (rebuilds session_costs + sessions.total_cost_usd
+  //    using current pricing). Project card totals are SUM(sessions.total_cost_usd),
+  //    so they refresh automatically once sessions are correct.
+  const sessions = db.query("SELECT DISTINCT session_id FROM events").all() as {
+    session_id: string;
+  }[];
+  const reaggregate = db.transaction((ids: typeof sessions) => {
+    for (const { session_id } of ids) {
+      updateSessionAggregates(db, session_id);
+    }
+  });
+  reaggregate(sessions);
+
+  db.run(
+    `INSERT INTO settings (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+    [RECOMPUTE_KEY, JSON.stringify(PRICING_VERSION)],
+  );
+
+  const ms = Math.round(performance.now() - startedAt);
+  console.log(
+    `[pricing] Recomputed costs for ${sessions.length} session(s) / ${eventRows.length} event(s) ` +
+      `after pricing change → version ${PRICING_VERSION} (${ms}ms)`,
+  );
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,7 @@ import { getDb } from "./db/connection";
 import { startWatcher } from "./ingestion/watcher";
 import { getSetting } from "./db/settings";
 import { loadPricingFromSettings } from "./db/pricing-loader";
+import { recomputePricingIfChanged } from "./db/pricing-migration";
 import { createApiRoutes } from "./api/projects";
 import { createSessionRoutes } from "./api/sessions";
 import { createEventRoutes } from "./api/events";
@@ -21,6 +22,10 @@ const db = getDb(`${config.dataDir}/db/telemetry.db`);
 
 // Load custom pricing from settings DB
 loadPricingFromSettings(db);
+
+// Recompute stored cost aggregates if the pricing table changed since last run
+// (e.g. a new model was added). No-op when pricing is unchanged.
+recomputePricingIfChanged(db);
 
 // Load server settings from DB (env vars take precedence)
 const dbPollInterval = getSetting(db, "server.pollInterval");

--- a/src/server/ingestion/pricing.ts
+++ b/src/server/ingestion/pricing.ts
@@ -3,7 +3,9 @@ export {
   type ModelPricing,
   type TokenUsage,
   PRICING,
+  PRICING_VERSION,
   getModelPricing,
   tokenTypeCost,
   calculateCost,
+  warnIfUnpriced,
 } from "../../shared/pricing";

--- a/src/server/ingestion/processor.ts
+++ b/src/server/ingestion/processor.ts
@@ -1,7 +1,7 @@
 // src/server/ingestion/processor.ts
 import type { Database } from "bun:sqlite";
 import { parseJsonlLine, extractEventData } from "./parser";
-import { calculateCost } from "./pricing";
+import { calculateCost, warnIfUnpriced } from "./pricing";
 import { upsertProject, upsertSession, insertEvent, updateSessionAggregates, upsertAgent, updateSessionTitle } from "../db/queries";
 
 export function processJsonlLine(db: Database, rawLine: string, projectSlug: string, chainId?: string): { eventId: string; sessionId: string; type: string } | null {
@@ -12,6 +12,9 @@ export function processJsonlLine(db: Database, rawLine: string, projectSlug: str
   if (!parsed.sessionId) return null;
 
   const event = extractEventData(parsed);
+
+  // Surface models we can't price so a silent $0 never slips through (warns once per model).
+  warnIfUnpriced(event.model);
 
   // Normalize git worktree cwd to the parent project path so worktree sessions
   // are grouped under the same project as their parent repo.

--- a/src/shared/pricing.ts
+++ b/src/shared/pricing.ts
@@ -14,13 +14,53 @@ export interface TokenUsage {
   cacheCreationTokens: number;
 }
 
-// Pricing as of March 2026 — update when new models launch
-export const PRICING: Record<string, ModelPricing> = {
+/**
+ * Bump whenever DEFAULT_PRICING changes. The server uses this to decide whether
+ * stored session/project cost aggregates need recomputing on startup (see
+ * db/pricing-migration.ts). Changing a rate without bumping this leaves stale
+ * cached costs in the DB.
+ */
+export const PRICING_VERSION = "2026-07-14";
+
+/**
+ * Default pricing, current as of July 2026 — update (and bump PRICING_VERSION)
+ * when new models launch. Cache rates follow Anthropic's standard schedule:
+ * cache-read = 0.1x input, cache-write (5-min) = 1.25x input.
+ *
+ * NOTE: Sonnet 5 has introductory pricing ($2/$10 through 2026-08-31); we use
+ * the standard $3/$15 to keep a single durable rate (time-varying pricing is
+ * not modeled here).
+ */
+export const DEFAULT_PRICING: Record<string, ModelPricing> = {
+  "claude-fable-5": {
+    inputPerMToken: 10,
+    outputPerMToken: 50,
+    cacheReadPerMToken: 1,
+    cacheWritePerMToken: 12.5,
+  },
+  "claude-opus-4-8": {
+    inputPerMToken: 5,
+    outputPerMToken: 25,
+    cacheReadPerMToken: 0.5,
+    cacheWritePerMToken: 6.25,
+  },
+  "claude-opus-4-7": {
+    inputPerMToken: 5,
+    outputPerMToken: 25,
+    cacheReadPerMToken: 0.5,
+    cacheWritePerMToken: 6.25,
+  },
   "claude-opus-4-6": {
     inputPerMToken: 5,
     outputPerMToken: 25,
     cacheReadPerMToken: 0.5,
     cacheWritePerMToken: 6.25,
+  },
+  "claude-sonnet-5": {
+    inputPerMToken: 3,
+    outputPerMToken: 15,
+    cacheReadPerMToken: 0.3,
+    cacheWritePerMToken: 3.75,
   },
   "claude-sonnet-4-6": {
     inputPerMToken: 3,
@@ -29,12 +69,25 @@ export const PRICING: Record<string, ModelPricing> = {
     cacheWritePerMToken: 3.75,
   },
   "claude-haiku-4-5": {
-    inputPerMToken: 0.80,
-    outputPerMToken: 4,
-    cacheReadPerMToken: 0.08,
-    cacheWritePerMToken: 1,
+    inputPerMToken: 1,
+    outputPerMToken: 5,
+    cacheReadPerMToken: 0.1,
+    cacheWritePerMToken: 1.25,
   },
 };
+
+/** Deep copy of the defaults so callers can't mutate the source of truth. */
+function freshDefaults(): Record<string, ModelPricing> {
+  const out: Record<string, ModelPricing> = {};
+  for (const [model, rates] of Object.entries(DEFAULT_PRICING)) {
+    out[model] = { ...rates };
+  }
+  return out;
+}
+
+// Live pricing table: starts as the defaults, may be overlaid with DB overrides
+// via loadPricingFromSettings(). Kept as a mutable object so overrides merge in place.
+export const PRICING: Record<string, ModelPricing> = freshDefaults();
 
 /** Short type-name to ModelPricing key mapping */
 const TYPE_TO_RATE: Record<string, keyof ModelPricing> = {
@@ -51,6 +104,26 @@ export function getModelPricing(model: string): ModelPricing | null {
   if (PRICING[model]) return PRICING[model];
   const base = model.replace(/-\d{8}$/, "");
   return PRICING[base] ?? null;
+}
+
+// Warn at most once per unpriced model so a $0 cost never passes silently.
+const _warnedUnknownModels = new Set<string>();
+
+/**
+ * Emit a one-time warning if `model` has token usage but no pricing entry.
+ * Call this at the ingestion boundary. Sentinel models like "<synthetic>"
+ * (Claude Code internal, non-billable) are ignored.
+ */
+export function warnIfUnpriced(model: string | null | undefined): void {
+  if (!model || model.startsWith("<")) return;
+  if (getModelPricing(model)) return;
+  if (_warnedUnknownModels.has(model)) return;
+  _warnedUnknownModels.add(model);
+  console.warn(
+    `[pricing] No pricing entry for model "${model}" — its cost is recorded as $0. ` +
+      `Add it to DEFAULT_PRICING in src/shared/pricing.ts (and bump PRICING_VERSION), ` +
+      `or override it via the pricing settings.`,
+  );
 }
 
 /**
@@ -76,14 +149,10 @@ export function clearPricingDirty(): void { _pricingDirty = false; }
 /** Returns true if pricing has been changed and needs reload. */
 export function isPricingDirty(): boolean { return _pricingDirty; }
 
-/** Reset pricing cache (for testing). */
+/** Reset pricing cache to the built-in defaults (for testing and reload). */
 export function invalidatePricingCache(): void {
   for (const key of Object.keys(PRICING)) delete (PRICING as any)[key];
-  Object.assign(PRICING, {
-    "claude-opus-4-6": { inputPerMToken: 5, outputPerMToken: 25, cacheReadPerMToken: 0.5, cacheWritePerMToken: 6.25 },
-    "claude-sonnet-4-6": { inputPerMToken: 3, outputPerMToken: 15, cacheReadPerMToken: 0.3, cacheWritePerMToken: 3.75 },
-    "claude-haiku-4-5": { inputPerMToken: 0.80, outputPerMToken: 4, cacheReadPerMToken: 0.08, cacheWritePerMToken: 1 },
-  });
+  Object.assign(PRICING, freshDefaults());
   _pricingDirty = false;
 }
 

--- a/test/server/pricing-migration.test.ts
+++ b/test/server/pricing-migration.test.ts
@@ -1,0 +1,79 @@
+// test/server/pricing-migration.test.ts
+import { describe, test, expect, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { applySchema } from "../../src/server/db/schema";
+import { upsertProject, upsertSession, insertEvent } from "../../src/server/db/queries";
+import { recomputePricingIfChanged } from "../../src/server/db/pricing-migration";
+import { invalidatePricingCache, PRICING_VERSION } from "../../src/shared/pricing";
+
+/** Insert one priced assistant event, simulating a session ingested when the
+ *  model was unpriced: stored per-event cost and session total left at 0. */
+function seedStaleSession(db: Database, model: string) {
+  upsertProject(db, "-proj", "proj", "/proj");
+  upsertSession(db, "sess-1", "-proj", { startedAt: "2026-07-01T00:00:00Z" });
+  insertEvent(db, {
+    id: "evt-1",
+    messageId: "msg-1",
+    sessionId: "sess-1",
+    type: "assistant",
+    timestamp: "2026-07-01T00:00:00Z",
+    model,
+    inputTokens: 1_000_000,
+    outputTokens: 1_000_000,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    costUsd: 0, // stale: computed as $0 when the model was unpriced
+    raw: "{}",
+  });
+  // Session aggregate left at default 0 (as if never re-aggregated since ingest)
+  db.run("UPDATE sessions SET total_cost_usd = 0 WHERE id = 'sess-1'");
+}
+
+describe("recomputePricingIfChanged", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = new Database(":memory:");
+    applySchema(db);
+    invalidatePricingCache();
+  });
+
+  test("recomputes stale $0 session + event costs for a now-priced model", () => {
+    seedStaleSession(db, "claude-opus-4-8");
+    // Force the migration to fire (schema backfill may have already run for this DB).
+    db.run("DELETE FROM settings WHERE key = 'migration_pricing_recompute'");
+
+    recomputePricingIfChanged(db);
+
+    // opus-4-8: 1M input @ $5 + 1M output @ $25 = $30
+    const session = db.query("SELECT total_cost_usd FROM sessions WHERE id = 'sess-1'").get() as { total_cost_usd: number };
+    expect(session.total_cost_usd).toBeCloseTo(30, 5);
+
+    const event = db.query("SELECT cost_usd FROM events WHERE id = 'evt-1'").get() as { cost_usd: number };
+    expect(event.cost_usd).toBeCloseTo(30, 5);
+  });
+
+  test("is a no-op when pricing version is unchanged", () => {
+    seedStaleSession(db, "claude-opus-4-8");
+    // Mark as already recomputed at the current version.
+    db.run(
+      "INSERT INTO settings (key, value) VALUES ('migration_pricing_recompute', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+      [JSON.stringify(PRICING_VERSION)],
+    );
+
+    recomputePricingIfChanged(db);
+
+    // Left untouched because the version matched.
+    const session = db.query("SELECT total_cost_usd FROM sessions WHERE id = 'sess-1'").get() as { total_cost_usd: number };
+    expect(session.total_cost_usd).toBe(0);
+  });
+
+  test("records the current pricing version after running", () => {
+    seedStaleSession(db, "claude-opus-4-8");
+    db.run("DELETE FROM settings WHERE key = 'migration_pricing_recompute'");
+
+    recomputePricingIfChanged(db);
+
+    const row = db.query("SELECT value FROM settings WHERE key = 'migration_pricing_recompute'").get() as { value: string };
+    expect(JSON.parse(row.value)).toBe(PRICING_VERSION);
+  });
+});

--- a/test/server/pricing.test.ts
+++ b/test/server/pricing.test.ts
@@ -10,6 +10,33 @@ describe("getModelPricing", () => {
     expect(pricing!.outputPerMToken).toBeGreaterThan(0);
   });
 
+  // Regression: current-generation models must be priced, or cost silently becomes $0.
+  test.each([
+    ["claude-opus-4-8", 5, 25],
+    ["claude-opus-4-7", 5, 25],
+    ["claude-sonnet-5", 3, 15],
+    ["claude-fable-5", 10, 50],
+  ])("prices %s at $%d/$%d per Mtok", (model, input, output) => {
+    const p = getModelPricing(model);
+    expect(p).not.toBeNull();
+    expect(p!.inputPerMToken).toBe(input);
+    expect(p!.outputPerMToken).toBe(output);
+    // cache rates follow Anthropic's standard 0.1x read / 1.25x write of input
+    expect(p!.cacheReadPerMToken).toBeCloseTo(input * 0.1, 5);
+    expect(p!.cacheWritePerMToken).toBeCloseTo(input * 1.25, 5);
+  });
+
+  test("prices Haiku 4.5 at current $1/$5 rate", () => {
+    const p = getModelPricing("claude-haiku-4-5");
+    expect(p).not.toBeNull();
+    expect(p!.inputPerMToken).toBe(1);
+    expect(p!.outputPerMToken).toBe(5);
+  });
+
+  test("prices current models via date-suffixed IDs", () => {
+    expect(getModelPricing("claude-opus-4-8-20260101")).not.toBeNull();
+  });
+
   test("returns pricing for model with date suffix", () => {
     const pricing = getModelPricing("claude-sonnet-4-6-20260301");
     expect(pricing).not.toBeNull();


### PR DESCRIPTION
## Problem

The two most recent projects (26-Travel, AI Adoptie) showed **$0.0000** cost despite tracking tens of millions of tokens. Root cause: the hardcoded `PRICING` table in `src/shared/pricing.ts` stopped at the `-4-6` generation, so sessions on `claude-opus-4-8` / `claude-opus-4-7` hit `getModelPricing() → null → cost 0`. Tokens were unaffected, which matched the symptom exactly.

## Fix

- **Add current models** — `opus-4-8`, `opus-4-7`, `sonnet-5`, `fable-5` (rates from the Anthropic pricing reference; cache = 0.1× read / 1.25× write of input).
- **Correct Haiku 4.5** from `$0.80/$4` to the current `$1/$5`.
- **Single source of truth** — `PRICING` and `invalidatePricingCache()` previously duplicated the table; the latter runs on every startup via `loadPricingFromSettings`, so a stale copy there would silently revert a pricing update. Both now derive from one `DEFAULT_PRICING`.
- **Warn on unpriced models** — `warnIfUnpriced()` logs once per unknown model at ingestion so a `$0` never passes silently again (sentinels like `<synthetic>` are skipped).
- **Recompute-on-startup migration** — `recomputePricingIfChanged()` re-aggregates session/project costs from stored tokens when `PRICING_VERSION` changes. Recomputes **purely from the DB** (never re-reads JSONL), so it is safe for older projects whose source logs are no longer on disk. Idempotent; runs once per pricing change.

## Verification

Rebuilt the running container; the migration recomputed **115 sessions / 16,845 events**. Live dashboard after the fix:

| Project | Before | After |
|---|---|---|
| 26-Travel | $0.0000 | **$17.07** |
| AI Adoptie | $0.0000 | **$101.52** |
| Claude Telemetry | $197.10 | $205.83 |

Tests: added regression coverage for the current models, the Haiku rate, and the recompute migration (`bun test` green apart from one pre-existing, unrelated FTS test on `main`).

## Follow-up

This fixes the symptom but the cost model is still static (hardcoded, recalculated at *current* rates rather than time-of-use). Tracked in #22.
